### PR TITLE
Verduidelijking active & hover

### DIFF
--- a/01_syntax.html
+++ b/01_syntax.html
@@ -910,7 +910,7 @@ a:hover {
 </code></pre>
             </li>
             <li class="fragment no-style">
-              &rarr; active is also hover, so link will be lightblue when active
+              &rarr; active happens after a click, most users still hover the link =&gt; both active and hover are true =&gt; link will be lightblue when active
             </li>
             <li class="fragment no-style">
               &rarr; solution: switch both fragments


### PR DESCRIPTION
De state :active is in deze situatie niet te zien omdat de meeste gebruikers (met cursor) nog hoveren boven de link na de klik. In de meeste gevallen wordt de actie van de link ondernomen voor de gebruiker zijn cursor verplaatst.
Misschien ook iets toevoegen dat dit niet meespeelt op een aanraakscherm omdat we daar doorgaans geen :hover hebben?
Hoewel dat niet echt veel te maken heeft met het onderwerp 'order' ...